### PR TITLE
refactor(douyin-extractor): generate `msToken`, `ac_nonce` and `odin_tt` params for each request

### DIFF
--- a/base/src/main/kotlin/github/hua0512/app/HttpClientProvider.kt
+++ b/base/src/main/kotlin/github/hua0512/app/HttpClientProvider.kt
@@ -76,7 +76,7 @@ class HttpClientFactory : IHttpClientFactory {
       level = LogLevel.NONE
     }
 
-    install(UserAgent) {
+    install(github.hua0512.utils.UserAgent) {
       agent = COMMON_USER_AGENT
     }
 

--- a/base/src/main/kotlin/github/hua0512/plugins/danmu/base/Danmu.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/danmu/base/Danmu.kt
@@ -278,6 +278,7 @@ abstract class Danmu(val app: App, val enablePing: Boolean = false) {
       .flowOn(Dispatchers.Default)
       .buffer()
       .onEach {
+        logger.trace("{}", it)
         addToBuffer(it)
       }
       .catch {

--- a/base/src/main/kotlin/github/hua0512/utils/Ktor.kt
+++ b/base/src/main/kotlin/github/hua0512/utils/Ktor.kt
@@ -1,0 +1,64 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.utils
+
+import io.ktor.client.plugins.api.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.util.logging.*
+import io.ktor.utils.io.*
+
+
+private val LOGGER = KtorSimpleLogger("io.ktor.client.plugins.UserAgent")
+
+/**
+ * A plugin that adds a `User-Agent` header to all requests.
+ * Only adds the header if it is not already set.
+ * @author hua0512
+ * @date : 2024/11/17 5:00
+ */
+@KtorDsl
+public class UserAgentConfig(public var agent: String = "Ktor http-client")
+
+/**
+ * A plugin that adds a `User-Agent` header to all requests.
+ *
+ * @property agent a `User-Agent` header value.
+ */
+public val UserAgent: ClientPlugin<UserAgentConfig> = createClientPlugin("UserAgent", ::UserAgentConfig) {
+
+  val agent = pluginConfig.agent
+
+  onRequest { request, _ ->
+    if (request.headers[HttpHeaders.UserAgent] != null) {
+//      LOGGER.trace("User-Agent header is already set for ${request.url}")
+      return@onRequest
+    }
+    LOGGER.trace("Adding User-Agent header: agent for ${request.url}")
+    request.header(HttpHeaders.UserAgent, agent)
+  }
+}

--- a/common/src/main/kotlin/github/hua0512/utils/String.kt
+++ b/common/src/main/kotlin/github/hua0512/utils/String.kt
@@ -27,7 +27,7 @@
 package github.hua0512.utils
 
 import java.security.MessageDigest
-import java.util.Base64
+import java.util.*
 
 /**
  * @author hua0512
@@ -70,11 +70,18 @@ fun String.nonEmptyOrNull(): String? = ifEmpty { null }
  * @param noUpperLetters A flag to indicate whether the string should not contain upper-case letters. Defaults to false.
  * @return A random string of the specified length.
  */
-fun generateRandomString(length: Int, noNumeric: Boolean = true, noUpperLetters: Boolean = false): String {
+fun generateRandomString(
+  length: Int,
+  noNumeric: Boolean = true,
+  noUpperLetters: Boolean = false,
+  lastChar: Char = 'z',
+  additionalLetters: Array<Char> = emptyArray(),
+): String {
   val allowedChars = buildList {
-    addAll('a'..'z')
+    addAll('a'..lastChar)
     if (!noNumeric) addAll('0'..'9')
     if (!noUpperLetters) addAll('A'..'Z')
+    if (additionalLetters.isNotEmpty()) addAll(additionalLetters)
   }
   return (1..length)
     .map { allowedChars.random() }

--- a/platforms/src/main/kotlin/github/hua0512/plugins/douyin/danmu/DouyinDanmu.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/douyin/danmu/DouyinDanmu.kt
@@ -39,16 +39,10 @@ import github.hua0512.data.stream.Streamer
 import github.hua0512.plugins.danmu.base.Danmu
 import github.hua0512.plugins.douyin.danmu.DouyinWebcastMessages.CHAT_MESSAGE
 import github.hua0512.plugins.douyin.danmu.DouyinWebcastMessages.CONTROL_MESSAGE
-import github.hua0512.plugins.douyin.download.DouyinApi
+import github.hua0512.plugins.douyin.download.*
 import github.hua0512.plugins.douyin.download.DouyinRequestParams.Companion.ROOM_ID_KEY
 import github.hua0512.plugins.douyin.download.DouyinRequestParams.Companion.SIGNATURE_KEY
 import github.hua0512.plugins.douyin.download.DouyinRequestParams.Companion.USER_UNIQUE_KEY
-import github.hua0512.plugins.douyin.download.extractDouyinWebRid
-import github.hua0512.plugins.douyin.download.fillDouyinCommonParams
-import github.hua0512.plugins.douyin.download.getSignature
-import github.hua0512.plugins.douyin.download.getValidUserId
-import github.hua0512.plugins.douyin.download.loadWebmssdk
-import github.hua0512.plugins.douyin.download.populateDouyinCookieMissedParams
 import github.hua0512.utils.decompressGzip
 import github.hua0512.utils.nonEmptyOrNull
 import github.hua0512.utils.withIOContext
@@ -100,18 +94,20 @@ open class DouyinDanmu(app: App) : Danmu(app, enablePing = false) {
     try {
       cookies = populateDouyinCookieMissedParams(cookies, app.client)
     } catch (e: Exception) {
-      logger.error("({}) Failed to populate douyin cookie missed params", webRid, e)
+      logger.error("{} Failed to populate douyin cookie missed params", webRid, e)
       return false
     }
 
     if (idStr.isEmpty()) {
-      logger.error("Failed to get douyin room id_str")
+      logger.error("{} Failed to get douyin room id_str", webRid)
       return false
     }
-    logger.info("(${streamer.name}) douyin room id_str: $idStr")
+    logger.info("${streamer.name} douyin room id_str: $idStr")
 
     with(requestParams) {
       fillDouyinCommonParams()
+      fillDouyinWsParams()
+
       this[ROOM_ID_KEY] = idStr
       updateSignature()
     }

--- a/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinApis.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinApis.kt
@@ -40,6 +40,7 @@ class DouyinApis {
 
   companion object {
 
+    internal const val BASE_URL = "https://www.douyin.com"
     internal const val LIVE_DOUYIN_URL = "https://live.douyin.com"
 
 

--- a/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinCombinedApiExtractor.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinCombinedApiExtractor.kt
@@ -57,6 +57,11 @@ class DouyinCombinedApiExtractor(http: HttpClient, json: Json, override val url:
         fillSecUid(secRid)
         // no id str check preset
         parameter(DouyinParams.ROOM_ID_KEY, idStr.ifEmpty { "2" })
+        // find msToken from cookies
+        val msToken = parseCookies(cookies)["msToken"]
+        if (msToken != null) {
+          parameter("msToken", msToken)
+        }
       }
       if (!(mobileResponse.status.isSuccess())) {
         throw InvalidExtractionResponseException("$url mobile api failed, status code = ${mobileResponse.status}")

--- a/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinCookie.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinCookie.kt
@@ -36,3 +36,4 @@ package github.hua0512.plugins.douyin.download
 internal const val ODIN_TT_COOKIE = "odin_tt"
 internal const val TT_WID_COOKIE = "ttwid"
 internal const val AC_NONCE_COOKIE = "__ac_nonce"
+internal const val MS_TOKEN_COOKIE = "msToken"

--- a/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinExtractor.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinExtractor.kt
@@ -38,6 +38,7 @@ import github.hua0512.plugins.douyin.download.DouyinApis.Companion.WEBCAST_ENTER
 import github.hua0512.utils.nonEmptyOrNull
 import io.ktor.client.*
 import io.ktor.client.plugins.*
+import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.json.*
@@ -85,6 +86,11 @@ open class DouyinExtractor(http: HttpClient, json: Json, override val url: Strin
         requestTimeoutMillis = 15000
       }
       fillWebRid(webRid)
+      // find msToken from cookies
+      val msToken = parseCookies(cookies)["msToken"]
+      if (msToken != null) {
+        parameter("msToken", msToken)
+      }
     }
     if (!(response.status.isSuccess())) throw InvalidExtractionResponseException("$url failed, status code = ${response.status}")
 
@@ -180,7 +186,7 @@ open class DouyinExtractor(http: HttpClient, json: Json, override val url: Strin
     // check if pull_datas is available (double screen streams)
     val pullDatas = liveData["stream_url"]!!.jsonObject["pull_datas"]?.jsonObject
 
-    val pullData = if (pullDatas != null && pullDatas.isNotEmpty()) {
+    val pullData = if (!pullDatas.isNullOrEmpty()) {
       // use the first pull_data
       pullDatas.entries.first().value.jsonObject
     } else {

--- a/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinHelpers.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinHelpers.kt
@@ -28,8 +28,7 @@ package github.hua0512.plugins.douyin.download
 
 import github.hua0512.plugins.base.exceptions.InvalidExtractionUrlException
 import github.hua0512.plugins.douyin.download.DouyinExtractor.Companion.URL_REGEX
-import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.parameter
+import io.ktor.client.request.*
 
 /** Utils for Douyin requests
  * @author hua0512
@@ -48,7 +47,6 @@ internal fun extractDouyinWebRid(url: String): String? {
   val roomIdPattern = URL_REGEX.toRegex()
   return roomIdPattern.find(url)?.groupValues?.get(1) ?: run {
     throw InvalidExtractionUrlException("Failed to get douyin room id from url: $url")
-    return null
   }
 }
 
@@ -66,6 +64,10 @@ internal fun HttpRequestBuilder.fillDouyinAppCommonParams() {
 
 internal fun MutableMap<String, String>.fillDouyinCommonParams() {
   putAll(DouyinParams.commonParams)
+}
+
+internal fun MutableMap<String, String>.fillDouyinWsParams() {
+  putAll(DouyinParams.websocketParams)
 }
 
 internal fun HttpRequestBuilder.fillWebRid(webRid: String) {

--- a/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinRequestParams.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinRequestParams.kt
@@ -71,21 +71,25 @@ internal class DouyinRequestParams {
      */
     internal val commonParams = mapOf(
       "app_name" to "douyin_web",
-      VERSION_CODE_KEY to VERSION_CODE_VALUE,
-      WEBCAST_SDK_VERSION_KEY to SDK_VERSION,
-      UPDATE_VERSION_CODE_KEY to SDK_VERSION,
       "compress" to "gzip",
       "device_platform" to "web",
       "browser_language" to "zh-CN",
       "browser_platform" to "Win32",
       "browser_name" to "Mozilla",
       "browser_version" to COMMON_USER_AGENT.removePrefix("Mozilla/").trim(),
-      "host" to "https://live.douyin.com",
       AID_KEY to AID_VALUE,
       "live_id" to "1",
+    )
+
+    internal val websocketParams = mapOf(
+      VERSION_CODE_KEY to VERSION_CODE_VALUE,
+      WEBCAST_SDK_VERSION_KEY to SDK_VERSION,
+      UPDATE_VERSION_CODE_KEY to SDK_VERSION,
+      "host" to DouyinApis.LIVE_DOUYIN_URL,
       "did_rule" to "3",
-      "endpoint" to "live_pc",
       "identity" to "audience",
+      "endpoint" to "live_pc",
+      "need_persist_msg_count" to "15",
       "heartbeatDuration" to "0",
     )
 

--- a/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinSignature.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/douyin/download/DouyinSignature.kt
@@ -71,9 +71,34 @@ private val signatureJS by lazy {
   val jsDom = """
     document = {};
     window = {};
+    Request = {};
+    Headers = {};
     navigator = {
       userAgent: '$COMMON_USER_AGENT'
     };
+    window.innerHeight = 910;
+    window.innerWidth = 1920;
+    window.outerHeight = 28;
+    window.outerWidth = 160;
+    window.screenX = 0;
+    window.screenY = 9;
+    window.pageYOffset = 0;
+    window.pageXOffset = 0;
+    window.screen = {}
+    window.onwheelx = {"_Ax": "0X21"}
+    window.navigator = navigator
+    window.navigator.cookieEnabled = true;
+    window.navigator.platform = "Win32";
+    window.navigator.language = "zh-CN";
+    window.navigator.appCodeName = "${COMMON_USER_AGENT.substringBefore('/')}";
+    window.navigator.appVersion = "$COMMON_USER_AGENT";
+    window.navigator.onLine = true;
+    window.addEventListener = function() {};
+    window.sessionStorage = {}
+    window.localStorage = {}
+    document.hidden = true;
+    document.webkitHidden = true;
+    document.cookie = '';
   """.trimIndent()
 
   // final JS

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractorV2.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractorV2.kt
@@ -77,7 +77,6 @@ class HuyaExtractorV2(override val http: HttpClient, override val json: Json, ov
       parameter("m", "Live")
       parameter("roomid", roomId)
       parameter("showSecret", "1")
-      url.parameters.remove(HttpHeaders.UserAgent)
       userAgent(IPHONE_WX_UA)
     }
 

--- a/platforms/src/test/kotlin/douyin/DouyinTest.kt
+++ b/platforms/src/test/kotlin/douyin/DouyinTest.kt
@@ -27,15 +27,17 @@
 package douyin
 
 import BaseTest
+import github.hua0512.data.config.DownloadConfig
 import github.hua0512.data.stream.Streamer
 import github.hua0512.plugins.douyin.danmu.DouyinDanmu
-import github.hua0512.plugins.douyin.download.DouyinExtractor
 import github.hua0512.plugins.douyin.download.DouyinCombinedApiExtractor
+import github.hua0512.plugins.douyin.download.DouyinExtractor
 import io.exoquery.pprint
 import kotlinx.coroutines.test.runTest
 import kotlin.test.DefaultAsserter.assertEquals
 import kotlin.test.DefaultAsserter.assertNotNull
 import kotlin.test.Test
+import kotlin.test.expect
 import kotlin.time.Duration
 
 /*
@@ -87,16 +89,28 @@ class DouyinTest : BaseTest() {
 
   @Test
   fun testDanmu(): Unit = runTest(timeout = Duration.INFINITE) {
+    val extractor = DouyinCombinedApiExtractor(app.client, app.json, testUrl).apply {
+      prepare()
+    }
+    val info = extractor.extract()
+
+    if (!info.live) {
+      assert(true)
+      return@runTest
+    }
+
     val danmu = DouyinDanmu(app).apply {
       enableWrite = false
       filePath = "douyin_danmu.txt"
-      idStr = ""
+      idStr = extractor.idStr
     }
-    val init = danmu.init(Streamer(0, "test", testUrl))
+    val init = danmu.init(Streamer(0, "test", testUrl, downloadConfig = DownloadConfig.DouyinDownloadConfig()))
     if (init) {
       danmu.fetchDanmu()
     }
-    assertNotNull("failed to get danmu", danmu)
+    expect(true) {
+      danmu.isInitialized.get()
+    }
     assert(init)
   }
 }

--- a/stream-rec/src/main/kotlin/github/hua0512/services/StreamerDownloadService.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/services/StreamerDownloadService.kt
@@ -449,8 +449,7 @@ class StreamerDownloadService(
           // in those cases, cancel the download and throw the exception
           is FatalDownloadErrorException, is CancellationException -> {
             updateStreamerState(StreamerState.FATAL_ERROR)
-            if (e !is CancellationException)
-              logger.error("{} fatal exception", streamer.name, e)
+            logger.error("{} fatal exception", streamer.name, e)
             throw e
           }
 


### PR DESCRIPTION
## Summary by Sourcery

Generate `msToken`, `ac_nonce`, and `odin_tt` parameters for each request, instead of generating them once.

New Features:
- Support generating `msToken`, `ac_nonce`, and `odin_tt` parameters for each request.

Tests:
- Update tests to reflect the changes in parameter generation.