### PR TITLE
feat(server): introduce extractor api

### DIFF
--- a/base/src/main/kotlin/github/hua0512/data/stream/StreamInfo.kt
+++ b/base/src/main/kotlin/github/hua0512/data/stream/StreamInfo.kt
@@ -36,6 +36,9 @@ import kotlinx.serialization.Serializable
  * @param quality the stream quality
  * @param bitrate the stream bitrate
  * @param priority the stream priority
+ * @param frameRate the stream frame rate
+ * @param extras the stream extras
+ * @param isHeadersNeeded whether custom headers are needed
  * @author hua0512
  * @date : 2024/3/15 20:37
  */
@@ -48,4 +51,5 @@ data class StreamInfo(
   val priority: Int = 0,
   val frameRate: Double = 0.0,
   val extras: Map<String, String> = emptyMap(),
+  val isHeadersNeeded: Boolean = false,
 )

--- a/base/src/main/kotlin/github/hua0512/plugins/base/Extractor.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/base/Extractor.kt
@@ -184,7 +184,10 @@ abstract class Extractor(protected open val http: HttpClient, protected open val
    * @param request the request builder
    * @return Result of the response
    */
-  suspend fun getResponse(url: String, request: HttpRequestBuilder.() -> Unit = {}): Result<HttpResponse, ExtractorError.ApiError> = runCatching {
+  suspend fun getResponse(
+    url: String,
+    request: HttpRequestBuilder.() -> Unit = {},
+  ): Result<HttpResponse, ExtractorError.ApiError> = runCatching {
     http.get(url) {
       populateCommons()
       request()
@@ -199,7 +202,10 @@ abstract class Extractor(protected open val http: HttpClient, protected open val
    * @param request the request builder
    * @return Result of the response
    */
-  suspend fun postResponse(url: String, request: HttpRequestBuilder.() -> Unit = {}): Result<HttpResponse, ExtractorError.ApiError> = runCatching {
+  suspend fun postResponse(
+    url: String,
+    request: HttpRequestBuilder.() -> Unit = {},
+  ): Result<HttpResponse, ExtractorError.ApiError> = runCatching {
     http.post(url) {
       populateCommons()
       request()
@@ -248,7 +254,8 @@ abstract class Extractor(protected open val http: HttpClient, protected open val
       if (playlist is MasterPlaylist) {
         val variants = playlist.variants()
         val variantStreams = variants.map { variant ->
-          val extraMap = variant.resolution().getOrNull()?.let { mapOf("resolution" to "${it.height()}x${it.width()}") } ?: emptyMap()
+          val extraMap = variant.resolution().getOrNull()?.let { mapOf("resolution" to "${it.height()}x${it.width()}") }
+            ?: emptyMap()
           StreamInfo(
             variant.uri(),
             format = VideoFormat.hls,

--- a/base/src/main/kotlin/github/hua0512/plugins/base/IExtractorFactory.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/base/IExtractorFactory.kt
@@ -24,37 +24,17 @@
  * SOFTWARE.
  */
 
-@file:OptIn(ExperimentalSerializationApi::class)
+package github.hua0512.plugins.base
 
-package github.hua0512.data.media
+interface IExtractorFactory {
 
-import github.hua0512.data.stream.StreamInfo
-import kotlinx.serialization.EncodeDefault
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.Serializable
 
-/**
- * A data class representing the media information
- * @property site the site where the media is from
- * @property title the title of the media
- * @property artist the artist of the media
- * @property coverUrl the cover image url of the media
- * @property artistImageUrl the artist image url of the media
- * @property live whether the media is live
- * @property streams the list of stream information
- * @property extras the extra information
- * @author hua0512
- * @date : 2024/3/15 20:29
- */
-@Serializable
-data class MediaInfo(
-  val site: String,
-  val title: String,
-  val artist: String,
-  val coverUrl: String,
-  val artistImageUrl: String,
-  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
-  val live: Boolean = false,
-  val streams: List<StreamInfo> = emptyList(),
-  val extras: Map<String, String> = emptyMap(),
-)
+  /**
+   * Get a matching extractor for the given url
+   *
+   * @param url The url to get extractor from
+   * @return Extractor instance or null if not found
+   */
+  fun getExtractorFromUrl(url: String, params: Map<String, List<String>>? = null): Extractor?
+
+}

--- a/platforms/src/test/kotlin/douyin/DouyinTest.kt
+++ b/platforms/src/test/kotlin/douyin/DouyinTest.kt
@@ -35,7 +35,6 @@ import github.hua0512.plugins.douyin.download.DouyinExtractor
 import io.exoquery.kmp.pprint
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
-import kotlin.test.DefaultAsserter.assertNotNull
 
 /*
  * MIT License
@@ -77,9 +76,11 @@ class DouyinTest : BaseTest<DouyinCombinedApiExtractor>({
 
   test("isLive") {
     val info = extractor.extract()
-    println(pprint(info))
+    println(info)
     info.isOk shouldBeEqual true
-    assertNotNull("failed to extract", info)
+    val mediaInfo = info.value
+    mediaInfo.shouldNotBeNull()
+    println(pprint(mediaInfo))
   }
 
   test("danmu") {
@@ -103,7 +104,7 @@ class DouyinTest : BaseTest<DouyinCombinedApiExtractor>({
 
 }) {
 
-  override val testUrl = "https://live.douyin.com/386003334438"
+  override val testUrl = "https://live.douyin.com/802975310822"
 
   override fun createExtractor(url: String) = DouyinCombinedApiExtractor(app.client, app.json, testUrl)
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   implementation(libs.io.ktor.server.call.id.jvm)
   implementation(libs.io.ktor.server.content.negotiation.jvm)
   implementation(libs.io.ktor.serialization.kotlinx.json.jvm)
+  implementation(libs.com.michael.bull.kotlin.result)
   implementation(libs.io.ktor.server.websockets.jvm)
   implementation(libs.ch.qos.logback.classic)
   testImplementation(libs.bundles.test.jvm)

--- a/server/src/main/kotlin/github/hua0512/backend/Server.kt
+++ b/server/src/main/kotlin/github/hua0512/backend/Server.kt
@@ -27,6 +27,7 @@
 package github.hua0512.backend
 
 import github.hua0512.backend.plugins.*
+import github.hua0512.plugins.base.IExtractorFactory
 import github.hua0512.repo.AppConfigRepo
 import github.hua0512.repo.UserRepo
 import github.hua0512.repo.stats.SummaryStatsRepo
@@ -49,13 +50,25 @@ fun CoroutineScope.backendServer(
   streamDataRepo: StreamDataRepo,
   statsRepo: SummaryStatsRepo,
   uploadRepo: UploadRepo,
+  extractorFactory: IExtractorFactory,
 ): EmbeddedServer<ApplicationEngine, NettyApplicationEngine.Configuration> {
   return embeddedServer(
     Netty,
     port = 12555,
     host = "0.0.0.0",
     parentCoroutineContext = parentContext,
-    module = { module(json, userRepo, appConfigRepo, streamerRepo, streamDataRepo, statsRepo, uploadRepo) })
+    module = {
+      module(
+        json,
+        userRepo,
+        appConfigRepo,
+        streamerRepo,
+        streamDataRepo,
+        statsRepo,
+        uploadRepo,
+        extractorFactory
+      )
+    })
 }
 
 fun Application.module(
@@ -66,11 +79,12 @@ fun Application.module(
   streamDataRepo: StreamDataRepo,
   statsRepo: SummaryStatsRepo,
   uploadRepo: UploadRepo,
+  extractorFactory: IExtractorFactory,
 ) {
   configureSecurity()
   configureHTTP()
   configureMonitoring()
   configureSerialization()
   configureSockets(json)
-  configureRouting(json, userRepo, appConfigRepo, streamerRepo, streamDataRepo, statsRepo, uploadRepo)
+  configureRouting(json, userRepo, appConfigRepo, streamerRepo, streamDataRepo, statsRepo, uploadRepo, extractorFactory)
 }

--- a/server/src/main/kotlin/github/hua0512/backend/plugins/Routing.kt
+++ b/server/src/main/kotlin/github/hua0512/backend/plugins/Routing.kt
@@ -1,6 +1,7 @@
 package github.hua0512.backend.plugins
 
 import github.hua0512.backend.routes.*
+import github.hua0512.plugins.base.IExtractorFactory
 import github.hua0512.repo.AppConfigRepo
 import github.hua0512.repo.UserRepo
 import github.hua0512.repo.stats.SummaryStatsRepo
@@ -23,6 +24,7 @@ fun Application.configureRouting(
   streamDataRepo: StreamDataRepo,
   statsRepo: SummaryStatsRepo,
   uploadRepo: UploadRepo,
+  extractorFactory: IExtractorFactory,
 ) {
   install(StatusPages) {
     exception<Throwable> { call, cause ->
@@ -42,6 +44,7 @@ fun Application.configureRouting(
         streamerRoute(streamerRepo)
         streamsRoute(json, streamDataRepo)
         uploadRoute(json, uploadRepo)
+        extractorRoutes(extractorFactory, json)
       }
     }
 

--- a/server/src/main/kotlin/github/hua0512/backend/routes/Extractor.kt
+++ b/server/src/main/kotlin/github/hua0512/backend/routes/Extractor.kt
@@ -1,0 +1,160 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.backend.routes
+
+import github.hua0512.backend.logger
+import github.hua0512.data.media.MediaInfo
+import github.hua0512.data.stream.StreamInfo
+import github.hua0512.plugins.base.IExtractorFactory
+import io.ktor.http.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.util.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.*
+
+
+fun Route.extractorRoutes(factory: IExtractorFactory, json: Json) {
+
+  route("/extract") {
+
+    get {
+      val url = call.request.queryParameters["url"]
+      val params = call.request.queryParameters.toMap().filterKeys { it != "url" }
+
+      logger.debug("Extracting url: {}, params: {}", url, params)
+
+      if (url.isNullOrEmpty()) {
+        call.respond(HttpStatusCode.OK, buildJsonObject {
+          put("msg", "url parameter is required")
+          put("code", 400)
+        })
+        return@get
+      }
+
+
+      val extractor =
+        factory.getExtractorFromUrl(url, params) ?: return@get call.respond(HttpStatusCode.OK, buildJsonObject {
+          put("msg", "No extractor found for the given url")
+          put("code", 404)
+        }.also {
+          logger.error("no extractor found: $it")
+        })
+
+      logger.debug("using extractor: {}", extractor)
+
+      val initResult = extractor.prepare()
+      if (initResult.isErr) {
+        return@get call.respond(HttpStatusCode.OK, buildJsonObject {
+          put("msg", "Failed to initialize extractor, ${initResult.error}")
+          put("code", 500)
+        })
+      }
+
+      val extractResult = extractor.extract()
+      if (extractResult.isErr) {
+        return@get call.respond(HttpStatusCode.OK, buildJsonObject {
+          put("msg", "Failed to extract data, ${extractResult.error}")
+          put("code", 500)
+        })
+      }
+
+      val mediaInfo = extractResult.value
+
+      return@get call.respond(HttpStatusCode.OK, buildJsonObject {
+        put("msg", "success")
+        put("code", 200)
+        put("data", json.encodeToJsonElement<MediaInfo>(MediaInfo.serializer(), mediaInfo))
+        put("headers", json.encodeToString(extractor.getRequestHeaders()))
+      }.also {
+        logger.info("extracted : $it")
+      })
+    }
+
+    post("/getTrueUrl") {
+      val body = call.receive<JsonObject>()
+      val url = body["url"]?.jsonPrimitive?.content ?: return@post call.respond(HttpStatusCode.OK, buildJsonObject {
+        put("msg", "url parameter is required")
+        put("code", 400)
+      })
+
+      val data: StreamInfo = body["data"]?.let {
+        json.decodeFromJsonElement(StreamInfo.serializer(), it)
+      } ?: return@post call.respond(HttpStatusCode.OK, buildJsonObject {
+        put("msg", "data parameter is required")
+        put("code", 400)
+      })
+
+      // only huya platform needs to call getTrueUrl at the moment
+      if (!url.contains("huya.com")) {
+        return@post call.respond(HttpStatusCode.OK, buildJsonObject {
+          put("msg", "success")
+          put("code", 200)
+          put("data", json.encodeToJsonElement(StreamInfo.serializer(), data))
+          put("headers", json.encodeToString(emptyMap<String, String>()))
+        }.also {
+          logger.debug("no need to call getTrueUrl: {}", it)
+        })
+      }
+
+      val extractor = factory.getExtractorFromUrl(url, emptyMap()) ?: return@post call.respond(HttpStatusCode.OK, buildJsonObject {
+        put("msg", "No extractor found for the given url")
+        put("code", 404)
+      }.also {
+        logger.error("true url extractor not found: $it")
+      })
+
+      val initResult = extractor.prepare()
+      if (initResult.isErr) {
+        return@post call.respond(HttpStatusCode.OK, buildJsonObject {
+          put("msg", "Failed to initialize extractor, ${initResult.error}")
+          put("code", 500)
+        })
+      }
+
+      val trueUrl = extractor.getTrueUrl(data)
+
+      if (trueUrl.isErr) {
+        return@post call.respond(HttpStatusCode.OK, buildJsonObject {
+          put("msg", "Failed to get true url, ${trueUrl.error}")
+          put("code", 500)
+        })
+      }
+
+      return@post call.respond(HttpStatusCode.OK, buildJsonObject {
+        put("msg", "success")
+        put("code", 200)
+        put("data", json.encodeToJsonElement(StreamInfo.serializer(), trueUrl.value))
+        put("headers", json.encodeToString(extractor.getRequestHeaders()))
+      }.also {
+        logger.debug("true url : {}", it)
+      })
+    }
+
+  }
+}

--- a/stream-rec/src/main/kotlin/github/hua0512/Application.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/Application.kt
@@ -149,6 +149,7 @@ class Application {
             appComponent.getStreamDataRepo(),
             appComponent.getStatsRepository(),
             appComponent.getUploadRepo(),
+            appComponent.getExtractorFactory(),
           ).apply {
             start()
           }

--- a/stream-rec/src/main/kotlin/github/hua0512/app/AppComponent.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/app/AppComponent.kt
@@ -28,6 +28,7 @@ package github.hua0512.app
 
 import dagger.Component
 import github.hua0512.dao.AppDatabase
+import github.hua0512.plugins.base.IExtractorFactory
 import github.hua0512.repo.AppConfigRepo
 import github.hua0512.repo.UserRepo
 import github.hua0512.repo.stats.SummaryStatsRepo
@@ -66,4 +67,6 @@ interface AppComponent {
   fun getStreamDataRepo(): StreamDataRepo
 
   fun getUploadRepo(): UploadRepo
+
+  fun getExtractorFactory(): IExtractorFactory
 }

--- a/stream-rec/src/main/kotlin/github/hua0512/app/AppModule.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/app/AppModule.kt
@@ -30,6 +30,7 @@ import dagger.Module
 import dagger.Provides
 import github.hua0512.dao.config.AppConfigDao
 import github.hua0512.dao.user.UserDao
+import github.hua0512.plugins.base.IExtractorFactory
 import github.hua0512.repo.LocalDataSource
 import github.hua0512.repo.LocalDataSourceImpl
 import github.hua0512.repo.stream.StreamDataRepo
@@ -37,6 +38,7 @@ import github.hua0512.repo.stream.StreamerRepo
 import github.hua0512.repo.upload.UploadRepo
 import github.hua0512.services.ActionService
 import github.hua0512.services.DownloadService
+import github.hua0512.services.ExtractorFactory
 import github.hua0512.services.UploadService
 import github.hua0512.utils.ThrowableSerializer
 import io.ktor.client.*
@@ -89,6 +91,10 @@ class AppModule {
   fun provideUploadService(app: App, uploadRepo: UploadRepo): UploadService = UploadService(app, uploadRepo)
 
   @Provides
-  fun provideLocalDataSource(appDao: AppConfigDao, userDao: UserDao): LocalDataSource = LocalDataSourceImpl(appDao, userDao)
+  fun provideLocalDataSource(appDao: AppConfigDao, userDao: UserDao): LocalDataSource =
+    LocalDataSourceImpl(appDao, userDao)
 
+  @Provides
+  @Singleton
+  fun provideExtractorFactory(client: HttpClient, json: Json): IExtractorFactory = ExtractorFactory(client, json)
 }

--- a/stream-rec/src/main/kotlin/github/hua0512/services/ExtractorFactory.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/services/ExtractorFactory.kt
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.services
+
+import github.hua0512.plugins.base.Extractor
+import github.hua0512.plugins.base.IExtractorFactory
+import github.hua0512.plugins.douyin.download.DouyinCombinedApiExtractor
+import github.hua0512.plugins.douyu.download.DouyuExtractor
+import github.hua0512.plugins.huya.download.HuyaExtractor
+import github.hua0512.plugins.huya.download.HuyaExtractorV2
+import github.hua0512.plugins.pandatv.download.PandaTvExtractor
+import github.hua0512.plugins.twitch.download.TwitchExtractor
+import github.hua0512.plugins.weibo.download.WeiboExtractor
+import github.hua0512.utils.mainLogger
+import io.ktor.client.*
+import io.ktor.http.*
+import kotlinx.serialization.json.Json
+import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
+
+class ExtractorFactory(val client: HttpClient, val json: Json) : IExtractorFactory {
+
+
+  val extractors = mapOf<String, KClass<*>>(
+    "live.douyin.com" to DouyinCombinedApiExtractor::class,
+    "www.douyu.com" to DouyuExtractor::class,
+    "www.huya.com" to HuyaExtractor::class,
+    "www.pandalive.co" to PandaTvExtractor::class,
+    "www.twitch.tv" to TwitchExtractor::class,
+    "www.weibo.com" to WeiboExtractor::class,
+  )
+
+
+  override fun getExtractorFromUrl(url: String, params: Map<String, List<String>>?): Extractor? {
+
+    if (url.contains("huya.com") && params?.get("type")?.firstOrNull() == "mobileApi") {
+      return HuyaExtractorV2(client, json, url)
+    }
+
+    // for example live.douyin.com
+    val host = Url(url).host
+
+    mainLogger.debug("host : $host")
+
+    val extractor = extractors[host] ?: return null
+
+    // TODO: Should migrate to use Ksp to generate the code instead of reflection, I hate it so much
+
+    return extractor.primaryConstructor?.let {
+      return it.call(client, json, url) as Extractor
+    }
+  }
+
+
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce an extractor API endpoint to retrieve stream information and handle true URL retrieval for specific platforms.

New Features:
- Added an extractor API endpoint that allows extracting stream information by providing a URL.
- Added support for true URL retrieval for platforms like Huya.

Tests:
- Updated tests to reflect the changes in the extractor API.