### PR TITLE
feat: add {platform} placeholder support

### DIFF
--- a/base/src/main/kotlin/github/hua0512/data/stream/StreamData.kt
+++ b/base/src/main/kotlin/github/hua0512/data/stream/StreamData.kt
@@ -3,7 +3,7 @@
  *
  * Stream-rec  https://github.com/hua0512/stream-rec
  *
- * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,6 +46,9 @@ data class StreamData(
 
   var streamerName: String = ""
     get() = streamer?.name ?: field
+
+  var platform: String = ""
+    get() = streamer?.platform?.name ?: field
 
   constructor(entity: StreamDataEntity, streamer: Streamer? = null) : this(
     entity.id,

--- a/base/src/main/kotlin/github/hua0512/data/upload/UploadData.kt
+++ b/base/src/main/kotlin/github/hua0512/data/upload/UploadData.kt
@@ -3,7 +3,7 @@
  *
  * Stream-rec  https://github.com/hua0512/stream-rec
  *
- * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -61,6 +61,8 @@ data class UploadData(
   var streamTitle = ""
     get() = streamData?.title ?: field
 
+  var platform = ""
+    get() = streamData?.platform ?: field
 
   var streamer = ""
     get() = streamData?.streamerName ?: field

--- a/base/src/main/kotlin/github/hua0512/plugins/download/base/PlatformDownloader.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/download/base/PlatformDownloader.kt
@@ -168,7 +168,7 @@ abstract class PlatformDownloader<T : DownloadConfig>(
     maxDownloadTime: Long = 0,
   ): Result<Boolean, ExtractorError> {
     this.streamer = streamer
-    this.context = StreamerContext(streamer.name, streamer.streamTitle.orEmpty())
+    this.context = StreamerContext(streamer.name, streamer.streamTitle.orEmpty(), streamer.platform.name)
     @Suppress("UNCHECKED_CAST")
     this.downloadConfig = streamer.downloadConfig as T
     val initialization = extractor.prepare()

--- a/base/src/main/kotlin/github/hua0512/plugins/download/engines/ffmpeg/FFmpegDownloadEngine.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/download/engines/ffmpeg/FFmpegDownloadEngine.kt
@@ -3,7 +3,7 @@
  *
  * Stream-rec  https://github.com/hua0512/stream-rec
  *
- * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -80,7 +80,7 @@ open class FFmpegDownloadEngine(override val logger: Logger = Companion.logger) 
     if (!useSegmenter) {
       lastOpeningFileTime = startInstant.epochSeconds
       // replace time placeholders if not using segmenter
-      outputFileName = outputFileName.replacePlaceholders(context.name, context.title, startInstant)
+      outputFileName = outputFileName.replacePlaceholders(context.name, context.title, context.platform, startInstant)
       // update downloadFilePath
       downloadFilePath = outputFolder.resolve(outputFileName).pathString
       lastOpeningFile = outputFileName
@@ -88,7 +88,7 @@ open class FFmpegDownloadEngine(override val logger: Logger = Companion.logger) 
   }
 
   private fun updateOutputFolder(startInstant: Instant) {
-    outputFolder = Path(downloadFilePath.replacePlaceholders(context.name, context.title, startInstant)).parent
+    outputFolder = Path(downloadFilePath.replacePlaceholders(context.name, context.title, context.platform, startInstant)).parent
     outputFolder.createDirectories()
   }
 

--- a/base/src/main/kotlin/github/hua0512/plugins/download/engines/kotlin/KotlinFlvDownloadEngine.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/download/engines/kotlin/KotlinFlvDownloadEngine.kt
@@ -70,7 +70,7 @@ class KotlinFlvDownloadEngine : KotlinDownloadEngine<FlvData>() {
   override val pathProvider: (Int) -> String = { _ ->
     val time = Clock.System.now()
     lastDownloadedTime = time.epochSeconds
-    downloadFilePath.replacePlaceholders(context.name, context.title, time).let {
+    downloadFilePath.replacePlaceholders(context.name, context.title, context.platform, time).let {
       val path = Path(it).apply {
         createParentDirectories()
         onDownloadStarted(it, time.epochSeconds)

--- a/base/src/main/kotlin/github/hua0512/plugins/download/engines/kotlin/KotlinHlsDownloadEngine.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/download/engines/kotlin/KotlinHlsDownloadEngine.kt
@@ -3,7 +3,7 @@
  *
  * Stream-rec  https://github.com/hua0512/stream-rec
  *
- * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,7 @@ class KotlinHlsDownloadEngine : KotlinDownloadEngine<HlsSegment>() {
   override val pathProvider: (Int) -> String = { index: Int ->
     val time = Clock.System.now()
     lastDownloadedTime = time.epochSeconds
-    downloadFilePath.replacePlaceholders(context.name, context.title, time).run {
+    downloadFilePath.replacePlaceholders(context.name, context.title, context.platform, time).run {
       // use parent folder for m3u8 with combining files disabled
       lastDownloadFilePath = Path(this).let {
         it.createParentDirectories()

--- a/base/src/main/kotlin/github/hua0512/plugins/upload/RcloneUploader.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/upload/RcloneUploader.kt
@@ -3,7 +3,7 @@
  *
  * Stream-rec  https://github.com/hua0512/stream-rec
  *
- * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -56,8 +56,9 @@ class RcloneUploader(app: App, override val config: RcloneConfig) : Upload<Rclon
     val startInstant = Instant.fromEpochSeconds(uploadData.streamStartTime)
     val streamer = uploadData.streamer
     val streamTitle = uploadData.streamTitle
+    val platform = uploadData.platform
 
-    val replacedRemote = remotePath.replacePlaceholders(streamer, streamTitle, startInstant)
+    val replacedRemote = remotePath.replacePlaceholders(streamer, streamTitle, platform, startInstant)
 
     val rcloneCommand = arrayOf(
       "rclone",

--- a/base/src/main/kotlin/github/hua0512/utils/StringPlaceholder.kt
+++ b/base/src/main/kotlin/github/hua0512/utils/StringPlaceholder.kt
@@ -31,9 +31,15 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
+
+private const val STREAMER_PLACEHOLDER = "{streamer}"
+private const val TITLE_PLACEHOLDER = "{title}"
+private const val PLATFORM_PLACEHOLDER = "{platform}"
+
 private val placeholders = arrayOf(
-  "{streamer}",
-  "{title}",
+  STREAMER_PLACEHOLDER,
+  TITLE_PLACEHOLDER,
+  PLATFORM_PLACEHOLDER,
   "%Y",
   "%m",
   "%d",
@@ -42,14 +48,15 @@ private val placeholders = arrayOf(
   "%S",
 )
 
-fun String.replacePlaceholders(streamer: String, title: String, time: Instant? = null): String {
+fun String.replacePlaceholders(streamer: String, title: String, platform: String? = null, time: Instant? = null): String {
   val localDateTime: LocalDateTime? = time?.toLocalDateTime(TimeZone.currentSystemDefault())
   val result = StringBuilder(this)
 
   for (placeholder in placeholders) {
     val value = when (placeholder) {
-      "{streamer}" -> streamer
-      "{title}" -> title
+      STREAMER_PLACEHOLDER -> streamer
+      TITLE_PLACEHOLDER -> title
+      PLATFORM_PLACEHOLDER -> platform
       "%Y" -> localDateTime?.year?.toString()
       "%m" -> localDateTime?.monthNumber?.let { formatLeadingZero(it) }
       "%d" -> localDateTime?.dayOfMonth?.let { formatLeadingZero(it) }

--- a/base/src/main/kotlin/github/hua0512/utils/StringPlaceholder.kt
+++ b/base/src/main/kotlin/github/hua0512/utils/StringPlaceholder.kt
@@ -31,7 +31,6 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
-
 private val placeholders = arrayOf(
   "{streamer}",
   "{title}",
@@ -43,57 +42,34 @@ private val placeholders = arrayOf(
   "%S",
 )
 
-/**
- * Extension function for the String class to replace placeholders in the string with provided values.
- *
- * @param streamer The name of the streamer. This value will replace the "{streamer}" placeholder in the string.
- * @param title The title of the stream. This value will replace the "{title}" placeholder in the string.
- * @param time The time of the stream as an Instant object. The date and time parts of this value will replace the corresponding placeholders in the string.
- * @return The string with all placeholders replaced with their corresponding values.
- */
 fun String.replacePlaceholders(streamer: String, title: String, time: Instant? = null): String {
-  // Define a map of placeholders to their replacement values
-  val toReplace: Map<String, String> = mapOf(
-    "{streamer}" to streamer,
-    "{title}" to title,
-  ) + if (time != null) {
-    // Convert the Instant time to a LocalDateTime object in the system's default time zone
-    val localDateTime: LocalDateTime = time.toLocalDateTime(TimeZone.currentSystemDefault())
-    mapOf(
-      "%Y" to localDateTime.year.toString(),
-      "%m" to formatLeadingZero(localDateTime.monthNumber),
-      "%d" to formatLeadingZero(localDateTime.dayOfMonth),
-      "%H" to formatLeadingZero(localDateTime.hour),
-      "%M" to formatLeadingZero(localDateTime.minute),
-      "%S" to formatLeadingZero(localDateTime.second),
-    )
-  } else {
-    emptyMap()
-  }
+  val localDateTime: LocalDateTime? = time?.toLocalDateTime(TimeZone.currentSystemDefault())
+  val result = StringBuilder(this)
 
-  // Replace each placeholder in the string with its corresponding value from the map and return the result
-  return toReplace.entries.fold(this) { acc, entry ->
-    acc.replace(entry.key, entry.value)
+  for (placeholder in placeholders) {
+    val value = when (placeholder) {
+      "{streamer}" -> streamer
+      "{title}" -> title
+      "%Y" -> localDateTime?.year?.toString()
+      "%m" -> localDateTime?.monthNumber?.let { formatLeadingZero(it) }
+      "%d" -> localDateTime?.dayOfMonth?.let { formatLeadingZero(it) }
+      "%H" -> localDateTime?.hour?.let { formatLeadingZero(it) }
+      "%M" -> localDateTime?.minute?.let { formatLeadingZero(it) }
+      "%S" -> localDateTime?.second?.let { formatLeadingZero(it) }
+      else -> null
+    } ?: continue
+
+    var index = result.indexOf(placeholder)
+    while (index != -1) {
+      result.replace(index, index + placeholder.length, value)
+      index = result.indexOf(placeholder, index + value.length)
+    }
   }
+  return result.toString()
 }
 
-/**
- * Formats an integer value to a string with a leading zero if the value is less than 10.
- * @param value The integer value to format.
- * @return The formatted string.
- */
 private fun formatLeadingZero(value: Int): String = String.format("%02d", value)
 
-/**
- * Extension function for the String class to extract the part of the string before any placeholders.
- * @return The part of the string before any placeholders.
- * If the string contains no placeholders, the entire string is returned.
- * If the string contains placeholders, only the part of the string before the first placeholder is returned.
- * If the string contains multiple placeholders, only the part of the string before the first placeholder is returned.
- * If the string contains a placeholder, but the placeholder is not found in the string, the entire string is returned.
- * If the string is empty, an empty string is returned.
- *
- */
 fun String.substringBeforePlaceholders(): String {
   if (this.isEmpty()) {
     return ""

--- a/base/src/test/kotlin/StringTest.kt
+++ b/base/src/test/kotlin/StringTest.kt
@@ -61,38 +61,52 @@ class StringTest : FunSpec({
   test("testPlaceholderReplace") {
     val streamer = "雪乃荔荔枝"
     val title = "新人第一天开播"
+    val platform = "bilibili"
     val time = 1708461712L
     val instant = Instant.fromEpochSeconds(time)
 
-    val fileFormat = "{streamer} - {title} - %Y-%m-%d %H-%M-%S"
+    val fileFormat = "{streamer} - {title} - {platform} - %Y-%m-%d %H-%M-%S"
 
-    val formatted = fileFormat.replacePlaceholders(streamer, title, instant)
+    val formatted = fileFormat.replacePlaceholders(streamer, title, platform, instant)
 
-    formatted shouldBeEqual "雪乃荔荔枝 - 新人第一天开播 - 2024-02-20 21-41-52"
+    formatted shouldBeEqual "雪乃荔荔枝 - 新人第一天开播 - huya - 2024-02-20 21-41-52"
   }
 
   test("testPlaceholderReplaceWithoutTime") {
     val streamer = "雪乃荔荔枝"
     val title = "新人第一天开播"
+    val platform = "bilibili"
 
-    val fileFormat = "{streamer} - {title} - %Y-%m-%d %H-%M-%S"
+    val fileFormat = "{streamer} - {title} - {platform}"
 
-    val formatted = fileFormat.replacePlaceholders(streamer, title)
+    val formatted = fileFormat.replacePlaceholders(streamer, title, platform)
 
-    formatted shouldBeEqual "雪乃荔荔枝 - 新人第一天开播 - %Y-%m-%d %H-%M-%S"
+    formatted shouldBeEqual "雪乃荔荔枝 - 新人第一天开播 - huya"
   }
 
   test("testPlaceholderReplaceWithEmptyString") {
     val streamer = ""
     val title = ""
+    val platform = ""
     val time = 1708461712L
     val instant = Instant.fromEpochSeconds(time)
 
-    val fileFormat = "{streamer} - {title} - %Y-%m-%d %H-%M-%S"
+    val fileFormat = "{streamer} - {title} - {platform} - %Y-%m-%d %H-%M-%S"
 
-    val formatted = fileFormat.replacePlaceholders(streamer, title, instant)
+    val formatted = fileFormat.replacePlaceholders(streamer, title, platform, instant)
 
-    formatted shouldBeEqual " -  - 2024-02-20 21-41-52"
+    formatted shouldBeEqual " -  -  - 2024-02-20 21-41-52"
+  }
+
+  test("testPlaceholderReplaceWithoutPlatform") {
+    val streamer = "雪乃荔荔枝"
+    val title = "新人第一天开播"
+
+    val fileFormat = "{streamer} - {title} - {platform}"
+
+    val formatted = fileFormat.replacePlaceholders(streamer, title)
+
+    formatted shouldBeEqual "雪乃荔荔枝 - 新人第一天开播 - {platform}"
   }
 
   test("testSubstringBeforePlaceholder") {

--- a/common/src/main/kotlin/github/hua0512/plugins/StreamerContext.kt
+++ b/common/src/main/kotlin/github/hua0512/plugins/StreamerContext.kt
@@ -3,7 +3,7 @@
  *
  * Stream-rec  https://github.com/hua0512/stream-rec
  *
- * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,4 +33,5 @@ package github.hua0512.plugins
 data class StreamerContext(
   val name: String,
   val title: String,
+  val platform: String,
 )

--- a/flv-processing/src/test/kotlin/github/hua0512/FixFlvTest.kt
+++ b/flv-processing/src/test/kotlin/github/hua0512/FixFlvTest.kt
@@ -113,7 +113,7 @@ class FixFlvTest {
     val pathProvider = { index: Int -> "E:/test/${file.nameWithoutExtension}_fix_${index}_${Clock.System.now().toEpochMilliseconds()}.flv" }
     val limitsProvider = { 0L to 3600.0f }
 
-    val streamerContext = StreamerContext("test", "")
+    val streamerContext = StreamerContext("test", "", platform = "test")
     source.asFlvFlow()
       .process(limitsProvider, streamerContext, duplicateTagFiltering = false)
       .analyze(metaInfoProvider, streamerContext)

--- a/stream-rec/src/main/kotlin/github/hua0512/services/ActionService.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/services/ActionService.kt
@@ -3,7 +3,7 @@
  *
  * Stream-rec  https://github.com/hua0512/stream-rec
  *
- * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,6 @@ import github.hua0512.data.upload.UploadAction
 import github.hua0512.data.upload.UploadConfig
 import github.hua0512.data.upload.UploadData
 import github.hua0512.utils.*
-import github.hua0512.utils.deleteFile
 import github.hua0512.utils.process.InputSource
 import github.hua0512.utils.process.Redirect
 import kotlinx.coroutines.async
@@ -43,13 +42,7 @@ import kotlinx.datetime.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
-import kotlin.io.path.Path
-import kotlin.io.path.copyTo
-import kotlin.io.path.createParentDirectories
-import kotlin.io.path.exists
-import kotlin.io.path.isDirectory
-import kotlin.io.path.moveTo
-import kotlin.io.path.name
+import kotlin.io.path.*
 
 /**
  * ActionService is responsible for running actions on the stream data
@@ -122,7 +115,7 @@ class ActionService(private val app: App, private val uploadService: UploadServi
           val downloadConfig = streamer.templateStreamer?.downloadConfig ?: streamer.downloadConfig
           val downloadOutputFolder: File? = (downloadConfig?.outputFolder?.nonEmptyOrNull() ?: app.config.outputFolder).let {
             val instant = Instant.fromEpochSeconds(streamData.dateStart!!)
-            val path = it.replacePlaceholders(streamer.name, streamData.title, instant)
+            val path = it.replacePlaceholders(streamer.name, streamData.title, streamer.platform.name, instant)
             Path(path).let { path ->
               if (!path.exists()) {
                 logger.error("Output folder $path does not exist")


### PR DESCRIPTION
## Summary by Sourcery

Add the `{platform}` placeholder. Update the copyright year to 2025.

New Features:
- Add support for the `{platform}` placeholder in filenames and paths, allowing users to include the platform name in their output files.
- Update copyright year to 2025 across multiple files

Tests:
- Add tests for the new `{platform}` placeholder functionality, covering cases with and without the platform value provided, as well as empty streamer and title values.