### PR TITLE
fix(string): replace invalid characters when building placeholders

### DIFF
--- a/base/src/main/kotlin/github/hua0512/utils/StringPlaceholder.kt
+++ b/base/src/main/kotlin/github/hua0512/utils/StringPlaceholder.kt
@@ -84,7 +84,7 @@ fun String.replacePlaceholders(streamer: String, title: String, platform: String
       index = result.indexOf(placeholder, index + value.length)
     }
   }
-  return result.toString().formatToFileNameFriendly()
+  return result.toString()
 }
 
 

--- a/base/src/main/kotlin/github/hua0512/utils/StringPlaceholder.kt
+++ b/base/src/main/kotlin/github/hua0512/utils/StringPlaceholder.kt
@@ -84,7 +84,7 @@ fun String.replacePlaceholders(streamer: String, title: String, platform: String
       index = result.indexOf(placeholder, index + value.length)
     }
   }
-  return result.toString()
+  return result.toString().formatToFileNameFriendly()
 }
 
 

--- a/common/src/main/kotlin/github/hua0512/utils/String.kt
+++ b/common/src/main/kotlin/github/hua0512/utils/String.kt
@@ -3,7 +3,7 @@
  *
  * Stream-rec  https://github.com/hua0512/stream-rec
  *
- * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ * Copyright (c) 2025 hua0512 (https://github.com/hua0512)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,14 @@ package github.hua0512.utils
 
 import java.security.MessageDigest
 import java.util.*
+
+
+/**
+ * A regex pattern to match invalid characters in file names.
+ */
+private val fileNameRegex by lazy {
+  Regex("[/\n\r\t\u0000\u000c`?*\\\\<>|\":']")
+}
 
 /**
  * @author hua0512
@@ -55,11 +63,10 @@ import java.util.*
  * - " (double quote)
  * - ' (single quote)
  *
- *
- * @receiver the file name to be formatted
- * @return a formatted file name
+ * @receiver the filename to be formatted
+ * @return a formatted filename
  */
-fun String.formatToFileNameFriendly(): String = replace(Regex("[/\n\r\t\u0000\u000c`?*\\\\<>|\":']"), "_")
+fun String.formatToFileNameFriendly(): String = replace(fileNameRegex, "_")
 
 
 /**

--- a/common/src/main/kotlin/github/hua0512/utils/String.kt
+++ b/common/src/main/kotlin/github/hua0512/utils/String.kt
@@ -36,10 +36,30 @@ import java.util.*
 
 /**
  * Format the file name to a friendly file name
+ * Replaces characters that are not allowed in file names with an underscore.
+ *
+ * Replaces the following characters with an underscore:
+ * - / (forward slash)
+ * - \ (backslash)
+ * - \n (newline)
+ * - \r (carriage return)
+ * - \t (tab)
+ * - \u0000 (null character)
+ * - \u000c (form feed)
+ * - ` (backtick)
+ * - ? (question mark)
+ * - * (asterisk)
+ * - < (less than)
+ * - > (greater than)
+ * - | (pipe)
+ * - " (double quote)
+ * - ' (single quote)
+ *
+ *
  * @receiver the file name to be formatted
  * @return a formatted file name
  */
-fun String.formatToFileNameFriendly(): String = replace(Regex("[/\n\r\t\u0000\u000c`?*\\\\<>|\":]"), "_")
+fun String.formatToFileNameFriendly(): String = replace(Regex("[/\n\r\t\u0000\u000c`?*\\\\<>|\":']"), "_")
 
 
 /**

--- a/platforms/src/main/kotlin/github/hua0512/plugins/twitch/download/Twitch.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/twitch/download/Twitch.kt
@@ -67,9 +67,11 @@ class Twitch(
       add("--twitch-disable-ads")
     }
     // configure streamlink-ttvlol options
-    config.twitchProxyPlaylist?.nonEmptyOrNull()?.let { add("--twitch-proxy-playlist=$it") }
+    config.twitchProxyPlaylist?.nonEmptyOrNull()?.let {
+      add("--twitch-proxy-playlist=$it")
+      if (config.twitchProxyPlaylistFallback) add("--twitch-proxy-playlist-fallback")
+    }
     config.twitchProxyPlaylistExclude?.nonEmptyOrNull()?.let { add("--twitch-proxy-playlist-exclude=$it") }
-    if (config.twitchProxyPlaylistFallback) add("--twitch-proxy-playlist-fallback")
   }
 
   private fun updateParams(config: AppConfig) {


### PR DESCRIPTION
fix #356

## Summary by Sourcery

Sanitize placeholder outputs and file name formatting by applying formatToFileNameFriendly after placeholder replacement and including the single quote in the invalid character regex

Bug Fixes:
- Include apostrophe in the list of characters replaced by formatToFileNameFriendly
- Apply file name sanitation to replacePlaceholders output to remove invalid characters