### PR TITLE
fix(twitch): update gql requests tokens

### DIFF
--- a/platforms/src/main/kotlin/github/hua0512/plugins/twitch/download/TwitchExtractor.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/twitch/download/TwitchExtractor.kt
@@ -85,7 +85,7 @@ class TwitchExtractor(http: HttpClient, json: Json, override val url: String) : 
     val queries = arrayOf(
       buildPersistedQueryRequest(
         "ChannelShell",
-        "c3ea5a669ec074a58df5c11ce3c27093fa38534c94286dc14b68a25d5adcbf55",
+        "fea4573a7bf2644f5b3f2cbbdcbee0d17312e48d2e55f080589d053aad353f11",
         buildJsonObject {
           put("login", id)
         }


### PR DESCRIPTION
## Summary by Sourcery

Update TwitchExtractor to use the latest persisted query tokens and adjust query payloads for compatibility with Twitch’s updated GraphQL API

Bug Fixes:
- Update persisted GraphQL query hashes in TwitchExtractor

Enhancements:
- Remove deprecated lcpVideosEnabled and previewImageURL variables and add includeIsDJ and platform parameters to GraphQL requests