### PR TITLE
Twitch/streamlink fix: switch docker base image to Debian for newer python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,23 @@
-FROM gradle:9.2.0-jdk21-alpine AS builder
+FROM gradle:9.2.0-jdk21 AS builder
 WORKDIR /app
 COPY . .
 RUN gradle stream-rec:build -x test
 
-FROM amazoncorretto:21-al2023-headless
+FROM debian:stable-slim
 WORKDIR /app
 COPY --from=builder /app/stream-rec/build/libs/stream-rec.jar app.jar
 
 # Install dependencies
-RUN yum update -y && \
-    yum install -y unzip tar python3 python3-pip which xz tzdata findutils && \
-    pip3 install streamlink && \
-    # install streamlink-ttvlol
-    INSTALL_DIR="/root/.local/share/streamlink/plugins"; mkdir -p "$INSTALL_DIR"; curl -L -o "$INSTALL_DIR/twitch.py" 'https://github.com/2bc4/streamlink-ttvlol/releases/latest/download/twitch.py' && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends python3 python3-pip tzdata curl default-jdk-headless rclone ffmpeg && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* /var/log/* /usr/share/man
 
-# Install ffmpeg with architecture check
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-      URL="https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-      URL="https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz"; \
-    fi && \
-    curl -L $URL | tar -xJ && \
-    mv ffmpeg-*-linux*/bin/{ffmpeg,ffprobe,ffplay} /usr/local/bin/ && \
-    chmod +x /usr/local/bin/{ffmpeg,ffprobe,ffplay} && \
-    rm -rf ffmpeg-*
 
-# Install rclone with architecture check
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-      URL="https://downloads.rclone.org/rclone-current-linux-amd64.zip"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-      URL="https://downloads.rclone.org/rclone-current-linux-arm64.zip"; \
-    fi && \
-    curl -L $URL -o rclone.zip && \
-    unzip rclone.zip && \
-    mv rclone-*-linux*/rclone /usr/bin/ && \
-    chown root:root /usr/bin/rclone && \
-    chmod 755 /usr/bin/rclone && \
-    rm -rf rclone.zip rclone-*
+# Install streamlink
+RUN pip3 install --break-system-packages streamlink
+# Install streamlink-ttvlol
+RUN INSTALL_DIR="/root/.local/share/streamlink/plugins"; mkdir -p "$INSTALL_DIR" && curl -L -o "$INSTALL_DIR/twitch.py" 'https://github.com/2bc4/streamlink-ttvlol/releases/latest/download/twitch.py'
 
 # Install strev with architecture check
 RUN ARCH=$(uname -m) && \


### PR DESCRIPTION
In the latest Docker image, streamlink for Twitch is broken, since streamlink-ttvlol requires streamlink 8.0.0 which is incompatible with Python 3.9.
Unfortunately, updating amazoncorretto to 25 does not fix the issue, since that release still ships with Python 3.9 (which is EOL).

The easiest fix I found, was to change the Docker base image to Debian, which also simplifies rclone/ffmpeg installation.

I have tested Twitch & streamlink and not found any issues, but I was not able to test other streaming platforms or rclone upload.